### PR TITLE
Thrusters are too needy.

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
+++ b/Resources/Prototypes/Entities/Structures/Shuttles/thrusters.yml
@@ -24,7 +24,7 @@
     - type: Appearance
     - type: ThrusterVisuals
     - type: ApcPowerReceiver
-      powerLoad: 1500
+      powerLoad: 500
     - type: ExtensionCableReceiver
     - type: Damageable
       damageContainer: Inorganic


### PR DESCRIPTION
I noticed this problem during the first test of the Nesasio where the APCs were unable to power the thrusters needed to give the Nesasio proper mobility in battle, I looked at the values after and found that each individual thruster consumes 1500 watts of energy per second, which is a LOT seeing as the PACMAN only produces 30000 watts of energy (20 thrusters worth).
APCs are also only able to supply 10000 watts of energy per second, which is enough for 6 thrusters. This would mean that in order for the Nesasio to operate in it's current state, there would need to be eight dedicated APCs for thrusters.

This high energy cost is not a problem in upstream as all the ships are very small and only need 4 thrusters in order to move at an acceptable speed, though here in Ekrixi ships need to be very fast for combat and can't be tiny like a cargo shuttle as they are the entire map the players operate on, so a lot of thrusters is a must even with the significant buff to their strength.

I've changed the value from 1500 to 500, this means that now it will take 60 thrusters to eat an entire PACMAN's supply, and 20 to completely drain an APC's supply limit.