### PR TITLE
Plastitanium Wall Upgrade

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -455,7 +455,7 @@
       thresholds:
         - trigger:
             !type:DamageTrigger
-            damage: 1000
+            damage: 16000
           behaviors:
             - !type:SpawnEntitiesBehavior
               spawn:


### PR DESCRIPTION
When reinforced walls and solid walls were upgraded to be MUCH stronger, plastitanium walls became the weakest wall in the game, which is not good as it was previously the toughest wall.
I've upgraded them to be twice as strong as armor plating (16000 HP), this lines up with armor plating being twice as strong as solid walls, even if it doesn't exactly match the 13.333x upgrade the other two walls had.