### PR TITLE
Shield Generator Wall

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Walls/walls.yml
+++ b/Resources/Prototypes/Entities/Structures/Walls/walls.yml
@@ -642,9 +642,9 @@
 
 - type: entity
   id: WallShuttleDiagonal
-  name: shuttle wall
+  name: shield generator
   suffix: diagonal
-  description: Keeps the air in and the greytide out.
+  description: A complex construction of machinery that can only be produced in a factory and breaks apart if pushed wrong. Reflects AP rounds, but is ineffective against explosives.
   placement:
     mode: SnapgridCenter
     snap:
@@ -716,7 +716,8 @@
 - type: entity
   parent: BaseWall
   id: WallShuttle
-  name: shuttle wall
+  name: shield generator
+  description: A complex construction of machinery that can only be produced in a factory and breaks apart if pushed wrong. Reflects AP rounds, but is ineffective against explosives.
   components:
   - type: Tag
     tags:


### PR DESCRIPTION
Rebrands the shuttle wall as the shield generator wall due to it's reflective properties. Still only has 500 HP and easily breaks when hit by HE or PF rounds. It does however reflect AP rounds away from the ship.

Not buildable by players, so it's an NPC map only thing.

![image](https://github.com/ekrixi-14/ekrixi/assets/140123969/967556cd-00f4-4b6c-9730-d12b1d064412)

"cool shader" not included