### PR TITLE
revert lizard diet from upstream

### DIFF
--- a/Resources/Prototypes/Body/Organs/reptilian.yml
+++ b/Resources/Prototypes/Body/Organs/reptilian.yml
@@ -4,11 +4,6 @@
   noSpawn: true
   components:
   - type: Stomach
-    specialDigestible:
-      tags:
-      - Fruit
-      - Meat
-      - Pill
   - type: SolutionContainerManager
     solutions:
       stomach:


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
<!-- What did you change in this PR? -->
Reverts lizard diet from upstream so lizards can eat whatever again

the alternative is whitelisting all the missing items or implementing the reagent based diet system I had planned for upstream:
(open link in a private window if you don't want your google account to be shown)
https://docs.google.com/document/d/1CkpiXiMytPH_oMKR-JLHjXFoukT4zpELZWygAmS-vPQ/edit

**Changelog**
:cl: Whisper
- remove: Removed lizard food whitelist, they can eat whatever again.
