### PR TITLE
Adjust captain's locker fill

### DIFF
--- a/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
+++ b/Resources/Prototypes/Catalog/Fills/Lockers/heads.yml
@@ -25,9 +25,9 @@
   components:
   - type: StorageFill
     contents:
-      - id: ClothingOuterArmorCaptainCarapace
-      - id: NukeDisk
-      - id: PinpointerNuclear
+#     - id: ClothingOuterArmorCaptainCarapace
+#      - id: NukeDisk
+#      - id: PinpointerNuclear
       - id: CaptainIDCard
       - id: ClothingOuterHardsuitCap
       - id: ClothingMaskGasCaptain
@@ -37,14 +37,14 @@
         amount: 3 # more than enough?
       - id: ClothingHeadsetAltCommand
       - id: SpaceCash1000
-      - id: PlushieNuke
-        prob: 0.1
-      - id: CigarGoldCase
-        prob: 0.25
-      - id: ClothingBeltSheathFilled
+#      - id: PlushieNuke
+#        prob: 0.1
+#      - id: CigarGoldCase
+#        prob: 0.25
+#      - id: ClothingBeltSheathFilled
       - id: DoorRemoteCommand
       - id: RubberStampCaptain
-      - id: WeaponAntiqueLaser
+#      - id: WeaponAntiqueLaser
       - id: JetpackCaptainFilled
       - id: MedalCase
 


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removes obsolete items from the captain's locker
- sabre sheath
- antique laser
- captain's carapace
- nuke disk, nuke pinpoinet, nukie plushie
- havian cigars
<!-- What did you change in this PR? -->

## Why / Balance
The captain already starts with an antique laser, so the 2nd one isn't needed. 
The captain also starts with a machete on their belt, which leaves the sabre as a direct upgrade should the captain want to powergame and immediately switch to the better weapon. The carapace is removed for the same reason.
Nuke and nukie stuff removed as there aren't any real nukes anywhere, and nukies similarly don't exist and don't have to be referenced.
The veil crossing crew is also a bit too destitute for havian cigars. Sorry, captain, you'll have to get at the plebean cigarettes with everyone else.
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media

- [X] This PR does not require an ingame showcase

