### PR TITLE
Machete now shows up on the character sprite

### DIFF
--- a/Resources/Textures/Objects/Weapons/Melee/machete.rsi/meta.json
+++ b/Resources/Textures/Objects/Weapons/Melee/machete.rsi/meta.json
@@ -10,6 +10,10 @@
         {
             "name": "icon"
         },
+		{
+        "name": "equipped-BELT",
+        "directions": 4
+		},
         {
             "name": "inhand-left",
             "directions": 4


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
I noticed alzore made spritework for the machete to show up when in the belt slot, but did a fucky wucky and didn't properly incorporate it. I fixed this.
<!-- What did you change in this PR? -->

## Why / Balance
bothered me
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
![Screenshot_1](https://github.com/ekrixi-14/ekrixi/assets/36332236/88b762aa-26b1-4a21-98ba-133eabe6548b)
![Screenshot_2](https://github.com/ekrixi-14/ekrixi/assets/36332236/3ebe0ae3-0bdf-48c8-a128-9b2754edfd30)
![Screenshot_3](https://github.com/ekrixi-14/ekrixi/assets/36332236/2db34986-6386-4d0b-a064-b82a7e4a74d8)
![Screenshot_4](https://github.com/ekrixi-14/ekrixi/assets/36332236/095c6e8f-5b25-4072-ac60-2ee09273ae57)


- [X] I have added screenshots/videos to this PR showcasing its changes ingame,

## Breaking changes
alzore bad