### PR TITLE
Add unobtainable VIE medicines

### DIFF
--- a/Resources/Locale/en-US/_ftl/reagents/meta/viem.ftl
+++ b/Resources/Locale/en-US/_ftl/reagents/meta/viem.ftl
@@ -1,0 +1,8 @@
+reagent-name-ves = Veil Exposure Seperator
+reagent-desc-ves = Causes chunks of flesh affected by the veil to fall off your body and onto the floor. Extraordinarily painful to use.
+
+reagent-name-vea = Veil Exposure Acidifier
+reagent-desc-vea = Targets areas of your body most heavily affected by VIE and painfully dissolves them. Can rarely end up damaging a vital organ.
+
+reagent-name-ven = Veil Nectar
+reagent-desc-ven = An exotic substance found in unusual parts of the veil capable of easily mending all damage caused by exposure.

--- a/Resources/Prototypes/_FTL/Entities/Objects/Specific/Medical/healing.yml
+++ b/Resources/Prototypes/_FTL/Entities/Objects/Specific/Medical/healing.yml
@@ -1,0 +1,111 @@
+- type: entity
+  name: pill (VES)
+  suffix: DO NOT MAP
+  parent: Pill
+  id: PillVES
+  components:
+  - type: Pill
+    pillType: 15
+  - type: Sprite
+    state: pill16
+  - type: Label
+    currentLabel: VES 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: VES
+          Quantity: 10
+
+- type: entity
+  name: pill canister (VES 10u)
+  parent: PillCanister
+  id: PillCanisterVES
+  suffix: VES, 5, DO NOT MAP
+  components:
+  - type: Label
+    currentLabel: VES 10u
+  - type: StorageFill
+    contents:
+    - id: PillVES
+      amount: 5
+
+- type: entity
+  name: pill (VEA)
+  suffix: DO NOT MAP
+  parent: Pill
+  id: PillVEA
+  components:
+  - type: Pill
+    pillType: 15
+  - type: Sprite
+    state: pill16
+  - type: Label
+    currentLabel: VEA 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: VEA
+          Quantity: 10
+
+- type: entity
+  name: pill canister (VEA 10u)
+  parent: PillCanister
+  id: PillCanisterVEA
+  suffix: VEA, 5, DO NOT MAP
+  components:
+  - type: Label
+    currentLabel: VEA 10u
+  - type: StorageFill
+    contents:
+    - id: PillVES
+      amount: 5
+
+- type: entity
+  name: pill (VIEM)
+  suffix: DO NOT MAP
+  parent: Pill
+  id: PillVIEM
+  components:
+  - type: Pill
+    pillType: 15
+  - type: Sprite
+    state: pill16
+  - type: Label
+    currentLabel: VIEM 10u
+  - type: SolutionContainerManager
+    solutions:
+      food:
+        maxVol: 20
+        reagents:
+        - ReagentId: VeilNectar
+          Quantity: 10
+
+- type: entity
+  name: VIEM injector
+  suffix: DO NOT MAP
+  parent: ChemicalMedipen
+  id: VIEMmedipen
+  description: A single-use injector that provides relief from flesh-eating VIE, useful for people put into a critical state.
+  components:
+  - type: Sprite
+    sprite: Objects/Specific/Medical/medipen.rsi
+    layers:
+    - state: penacid
+      map: ["enum.SolutionContainerLayers.Fill"]
+  - type: SolutionContainerVisuals
+    maxFillLevels: 1
+    changeColor: false
+    emptySpriteName: penacid_empty
+  - type: SolutionContainerManager
+    solutions:
+      pen:
+        maxVol: 20
+        reagents:
+        - ReagentId: VeilNectar
+          Quantity: 20
+  - type: Tag
+    tags: []

--- a/Resources/Prototypes/_FTL/Reagents/medicine.yml
+++ b/Resources/Prototypes/_FTL/Reagents/medicine.yml
@@ -1,0 +1,56 @@
+- type: reagent
+  id: VES
+  name: reagent-name-ves
+  group: Medicine
+  desc: reagent-desc-ves
+  physicalDesc: reagent-physical-desc-overpowering
+  flavor: medicine
+  color: "#bd5902"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            VeilIndividualExposure: -1
+          groups:
+            Brute: 6
+      - !type:Emote
+        emote: Scream
+        probability: 0.6
+
+- type: reagent
+  id: VEA
+  name: reagent-name-vea
+  group: Medicine
+  desc: reagent-desc-vea
+  physicalDesc: reagent-physical-desc-bubbling
+  flavor: medicine
+  color: "#bd5902"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            VeilIndividualExposure: -2
+            Caustic: 3.5
+      - !type:Emote
+        emote: Scream
+        probability: 0.3
+
+- type: reagent
+  id: VeilNectar #admin only chemical don't put this anywhere
+  name: reagent-name-ven
+  group: Medicine
+  desc: reagent-desc-ven
+  physicalDesc: reagent-physical-desc-exotic-smelling
+  flavor: medicine
+  color: "#bd5902"
+  metabolisms:
+    Medicine:
+      effects:
+      - !type:HealthChange
+        damage:
+          types:
+            VeilIndividualExposure: -10

--- a/Resources/Prototypes/_FTL/Reagents/medicine.yml
+++ b/Resources/Prototypes/_FTL/Reagents/medicine.yml
@@ -4,8 +4,8 @@
   group: Medicine
   desc: reagent-desc-ves
   physicalDesc: reagent-physical-desc-overpowering
-  flavor: medicine
-  color: "#bd5902"
+  flavor: horrible
+  color: "#BA275D"
   metabolisms:
     Medicine:
       effects:
@@ -25,16 +25,16 @@
   group: Medicine
   desc: reagent-desc-vea
   physicalDesc: reagent-physical-desc-bubbling
-  flavor: medicine
-  color: "#bd5902"
+  flavor: acid
+  color: "#BC9207"
   metabolisms:
     Medicine:
       effects:
       - !type:HealthChange
         damage:
           types:
-            VeilIndividualExposure: -2
-            Caustic: 3.5
+            VeilIndividualExposure: -1
+            Caustic: 1.75
       - !type:Emote
         emote: Scream
         probability: 0.3
@@ -45,12 +45,12 @@
   group: Medicine
   desc: reagent-desc-ven
   physicalDesc: reagent-physical-desc-exotic-smelling
-  flavor: medicine
-  color: "#bd5902"
+  flavor: cold
+  color: "#DCA0FF"
   metabolisms:
     Medicine:
       effects:
       - !type:HealthChange
         damage:
           types:
-            VeilIndividualExposure: -10
+            VeilIndividualExposure: -5


### PR DESCRIPTION
## About the PR
Adds 3 VIE meds
VES = 12 brute damage, 2 VIE healed
VEA = 3.5 caustic damage, 2 VIE healed
Veil Nectar/VIEM = 10 VIE healed with no downsides (will never be regularly obtainable)

IPCs still have no way to heal VIE though.

## Why / Balance
Hitting people with the debug VIE stick and making them eat mopwata pills got annoying
