### PR TITLE
Fix VIE causing absurd amounts of bleeding

### DIFF
--- a/Resources/Prototypes/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/Damage/modifier_sets.yml
@@ -251,6 +251,7 @@
     Bloodloss: 0.0 # no double dipping
     Cellular: 0.0
     Caustic: 0.0
+    VeilIndividualExposure: 0.0
 
 - type: damageModifierSet
   id: SlimePet # Very survivable slimes


### PR DESCRIPTION
## About the PR
There's a damage modifier set that controls how much someone bleeds, I have added VIE to that set with a 0.0 multiplier.

## Why / Balance
VIE is now invisible and not insanely annoying with the little bleeding popup every 2 minutes.