### PR TITLE
DETHRONE Nesasio

### DIFF
--- a/Resources/ConfigPresets/Ekrixi/ekrixi.toml
+++ b/Resources/ConfigPresets/Ekrixi/ekrixi.toml
@@ -6,7 +6,7 @@ max_connections         = 1024
 desc                    = "Ekrixi is a PvE fork of SS14 revolving around PvE gameplay, ship travel, and roleplay."
 lobbyenabled            = true
 soft_max_players        = 50
-map                     = "Nesasio"
+map                     = "Cestoda"
 map_pool                = "FTLMapPool"
 
 [minplayers]

--- a/Resources/Prototypes/_FTL/Maps/Pools/ftl.yml
+++ b/Resources/Prototypes/_FTL/Maps/Pools/ftl.yml
@@ -2,7 +2,7 @@
   id: FTLMapPool
   maps:
 #    - Nesasio # Temporarily taken out of rotation due to the lack of a warp drive
-    - Stormwalker
-    - THERODTWO
+#    - Stormwalker # Temporarily taken out of rotation due to the lack of a warp drive
+#    - THERODTWO # Temporarily taken out of rotation due to the lack of a warp drive
     - Cestoda
     - Myrmeleon


### PR DESCRIPTION
<!-- Please read these guidelines before opening your PR: https://docs.spacestation14.io/en/getting-started/pr-guideline -->
<!-- The text between the arrows are comments - they will not be visible on your PR. -->

## About the PR
Removes THERODTWO, Stormwalker and Nesasio from the map pool.
Replaces Nesasio with Cestoda as the default map, so that it's properly derotated and doesn't show up.
<!-- What did you change in this PR? -->

## Why / Balance
None of those maps are updated to current standard (missing warp drives)
<!-- Why was it changed? Link any discussions or issues here. Please discuss how this would affect game balance. -->

## Media
<!-- 
PRs which make ingame changes (adding clothing, items, new features, etc) are required to have media attached that showcase the changes.
Small fixes/refactors are exempt.
Any media may be used in SS14 progress reports, with clear credit given.

If you're unsure whether your PR will require media, ask a maintainer.

Check the box below to confirm that you have in fact seen this (put an X in the brackets, like [X]):
-->

- [X] This PR does not require an ingame showcase