### PR TITLE
Give IPCs their own damage modifier set

### DIFF
--- a/Resources/Prototypes/_FTL/Damage/modifier_sets.yml
+++ b/Resources/Prototypes/_FTL/Damage/modifier_sets.yml
@@ -1,0 +1,11 @@
+- type: damageModifierSet
+  id: Robotic
+  coefficients:
+    Blunt: 1.2
+    Slash: 0.8
+    Piercing: 1
+    Shock: 1.5
+    Poison: 0.0 #Robots can't be poisoned.
+    Radiation: 0.15 #They have no way of repairing this so it's low, but radiation screws with elecronics just as much as people. Set this to 1 or 1.2 when we get brain surgery.
+    Bloodloss: 0.0 #They take heat damage instead and there are enemies that deal bloodloss on hit.
+    Cellular: 0.0 #Robots don't have DNA

--- a/Resources/Prototypes/_FTL/Entities/Mobs/Species/ipc.yml
+++ b/Resources/Prototypes/_FTL/Entities/Mobs/Species/ipc.yml
@@ -14,7 +14,7 @@
       species: IPC
     - type: Damageable
       damageContainer: Biological
-      damageModifierSet: Metallic
+      damageModifierSet: Robotic
     - type: Icon
       sprite: Mobs/Species/Arachnid/parts.rsi
       state: full


### PR DESCRIPTION
## About the PR
Gives IPCs their own damage modifier set. They're weak to blunt and resist slash. Shocks hurt a lot and they're immune to poison.

## Why / Balance
IPCS ARE NO LONGER INVINCIBLE LET'S GOOO
they literally used to use the solid wall damage modifier set which had FLAT RESISTS FOR BLUNT AND HEAT