### PR TITLE
Un-hardcode the warp drive charging duration

### DIFF
--- a/Content.Server/_FTL/FTLPoints/Components/WarpDriveComponent.cs
+++ b/Content.Server/_FTL/FTLPoints/Components/WarpDriveComponent.cs
@@ -19,10 +19,13 @@ public sealed partial class WarpDriveComponent : Component
     public int FuelPerJump = 30;
 
     /// <summary>
-    /// Ships at max charge (1f) will instantly begin jumping
+    /// Ships will begin warping when Charge reaches ChargeNeeded
     /// </summary>
-    [DataField, ViewVariables]
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
     public float Charge;
+
+    [DataField, ViewVariables(VVAccess.ReadWrite)]
+    public int ChargeNeeded = 30;
 
     /// <summary>
     /// Is this drive charging?

--- a/Content.Server/_FTL/FTLPoints/Systems/FtlPointsSystem.WarpDrive.cs
+++ b/Content.Server/_FTL/FTLPoints/Systems/FtlPointsSystem.WarpDrive.cs
@@ -59,10 +59,10 @@ public sealed partial class FtlPointsSystem
             if (!TryComp<ShuttleComponent>(grid, out var shuttleComponent))
                 return;
 
-            if (component is { Charging: true, Charge: < 1 })
-                component.Charge += frameTime / 30;
+            if (component.Charging && component.Charge < component.ChargeNeeded)
+                component.Charge += frameTime;
 
-            if (!(component.Charge >= 1))
+            if (component.Charge < component.ChargeNeeded)
                 continue;
 
             if (!warpingShipComponent.TargetMap.HasValue)
@@ -90,13 +90,13 @@ public sealed partial class FtlPointsSystem
             return;
         }
 
-        if (component.Charge >= 1)
+        if (component.Charge >= component.ChargeNeeded)
         {
             args.PushMarkup(Loc.GetString("drive-examined-ready"));
             return;
         }
 
         args.PushMarkup(Loc.GetString("drive-examined", ("charging", component.Charging), ("charge",
-            $"{(component.Charge * 100):F}"), ("destination", warpingShipComponent.TargetMap != null)));
+            $"{(component.Charge / component.ChargeNeeded * 100):F}"), ("destination", warpingShipComponent.TargetMap != null)));
     }
 }

--- a/Resources/Prototypes/_FTL/Entities/Structures/Machines/warp-drive.yml
+++ b/Resources/Prototypes/_FTL/Entities/Structures/Machines/warp-drive.yml
@@ -28,3 +28,12 @@
     - type: PointLight
       radius: 2.5
       energy: 0.5
+
+- type: entity
+  id: WarpDrive
+  name: super warp drive
+  description: It go fast!!
+  suffix: DEBUG
+  components:
+    - type: WarpDrive
+      ChargeNeeded: 0.1

--- a/Resources/Prototypes/_FTL/Entities/Structures/Machines/warp-drive.yml
+++ b/Resources/Prototypes/_FTL/Entities/Structures/Machines/warp-drive.yml
@@ -30,7 +30,7 @@
       energy: 0.5
 
 - type: entity
-  id: WarpDrive
+  id: WarpDriveDebug
   name: super warp drive
   description: It go fast!!
   suffix: DEBUG


### PR DESCRIPTION
## About the PR
Added a debug warp drive and made the variables able to be changed.

## Why / Balance
Debug warp drives are helpful

## Technical details
- WarpDriveComponent now has a new datafield that dictates how many seconds it takes before the warp drive is ready to warp.
- FtlPointsSystem.WarpDrive now decides percentages and when it's ready to charge based on comparisons between the current Charge and ChargeNeeded
