### PR TITLE
Make windows connect with walls

### DIFF
--- a/Resources/Prototypes/Entities/Structures/Windows/window.yml
+++ b/Resources/Prototypes/Entities/Structures/Windows/window.yml
@@ -71,7 +71,7 @@
         acts: [ "Destruction" ]
   - type: Airtight
   - type: IconSmooth
-    key: windows
+    key: walls
     base: window
   - type: InteractionPopup
     interactSuccessString: comp-window-knock


### PR DESCRIPTION
## About the PR
Windows now use the same iconsmooth key as walls.

## Why / Balance
It was ugly before

## Media
![image](https://github.com/ekrixi-14/ekrixi/assets/140123969/8c1047b8-c9f2-4d84-ae4f-b4d82410a0aa)
